### PR TITLE
Add links to the INT site and production

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ navigation_weight: 1
 *This is based on my 5 minute CIQS/SAW infomercial at the All Hands on February, 24th. Putting it here as a placeholder for now.* -andrew
 # Hello everybody.
 
+Go to solution authoring in [INT](https://caqsint.azure.net/CustomSolutions) or [PROD](https://start.cortanaintelligence.com/CustomSolutions).
+
 Some of you may have heard about *CIQS* or *Cortana Intelligence Quick Start*, the deployment engine behind *Cortana Intelligence Solutions*. For those who haven't, *CIQS* is the service that orchestrates solution deployment into a customer's *Azure* subscription by performing a series of provisioning activities that generally fall into such categories as
 - Cloud resource creation (essentially, things that can be achieved with ARM templates)
 - Execution of custom provisioning code (things that are not possible to achieve with ARM)


### PR DESCRIPTION
https://msdata.visualstudio.com/AlgorithmsAndDataScience/_workitems?id=54241&_a=edit&triage=false
7. (Following above question) Which section(s) of documentation you would like us to improve? (Optional) 

Add links to the INT site and production site can be helpful. This will allow users go to the sites from the documentation. https://caqsint.azure.net/CustomSolutions https://start.cortanaintelligence.com/CustomSolutions  (lixzhang)